### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/continuous.delivery.yml
+++ b/.github/workflows/continuous.delivery.yml
@@ -143,21 +143,13 @@ jobs:
       - name: Upload release asset
 
         run: |
-
           curl -L \
-
             -X POST \
-
             -H "Accept: application/vnd.github+json" \
-
             -H "Authorization: Bearer ${{ steps.generate-app-token.outputs.token }}" \
-
             -H "X-GitHub-Api-Version: 2022-11-28" \
-
             -H "Content-Type: application/octet-stream" \
-
             "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.draft-release.outputs.result }}/assets?name=${{ env.SITE_DIR }}.zip" \
-
             --data-binary "@${{ env.SITE_DIR }}.zip"
 
 

--- a/.github/workflows/continuous.deployment.yml
+++ b/.github/workflows/continuous.deployment.yml
@@ -85,47 +85,26 @@ jobs:
         id: download-release-asset
 
         run: |
-
           cat << 'EOF' > event.json
-
           ${{ toJson(github.event) }}
-
           EOF
-
           asset_id=$(cat event.json | jq '.release.assets[] | select(.name == "${{ env.SITE_DIR }}.zip") | .id')
-
-
-
           curl --location --output '${{ env.SITE_DIR }}.zip'                          \
-
             -H "Accept: application/octet-stream"                                     \
-
             -H "Authorization: Bearer ${{ steps.generate-app-token.outputs.token }}"  \
-
             -H "X-GitHub-Api-Version: 2022-11-28"                                     \
-
             "https://api.github.com/repos/${{ github.repository }}/releases/assets/${asset_id}"
 
 
-
           unzip -o "${{ env.SITE_DIR }}.zip" -d .
-
-
-
           echo '##### Debug'
-
           ls -al "${{ env.SITE_DIR }}"
-
-
 
       - name: Fix site file permissions
 
         run: |
-
           chmod -c -R +rX "${{ env.SITE_DIR }}/" | while read line; do
-
             echo "::warning title=Invalid file permissions automatically fixed::$line"
-
           done
 
 

--- a/.github/workflows/continuous.versioning.yml
+++ b/.github/workflows/continuous.versioning.yml
@@ -1,6 +1,7 @@
 name: Version Changes to the Main Branch
 
-
+permissions:
+  contents: write
 
 on:
 


### PR DESCRIPTION
Potential fix for [https://github.com/jesusbuck/github-devsecops-fundamentals/security/code-scanning/1](https://github.com/jesusbuck/github-devsecops-fundamentals/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to define the minimal permissions required for the workflow. Based on the workflow's operations, it needs `contents: write` to create and push tags. This ensures the workflow has only the necessary permissions and avoids granting excessive access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
